### PR TITLE
more flexible entity implementation

### DIFF
--- a/source/Entity.hpp
+++ b/source/Entity.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <vector>
-
+#include <tuple>
 #include "EObject.hpp"
 #include "LevelObject.hpp"
 
@@ -9,28 +9,30 @@
 
 using namespace std;
 
+template<typename... Components>
 class Entity : public LevelObject
 {
 public:
+    Entity() = default;
+    Entity(Components&&... components)
+        : m_components(std::forward<Components>(components)...) {}
 
-	vec3 Position = vec3();
+    virtual ~Entity() = default;
+    virtual void Destroy() {}
 
-	vec3 Rotation = vec3();
+    
+    template<typename T>
+    T& get()
+    {
+        return std::get<T>(m_components);
+    }
 
-	Entity()
-	{
-
-	}
-	~Entity()
-	{
-
-	}
-
-	void virtual Destroy()
-	{
-
-	}
+    template<typename T>
+    const T& get() const
+    {
+        return std::get<T>(m_components);
+    }
 
 private:
-
+    std::tuple<Components...> m_components;
 };


### PR DESCRIPTION
instead of hardcoding your definition of an object in a game and emposing it to your entity class
decouple the definition of entity and a game object

Entity<Transform, SkinnedModel, ...> player;
Entity<Transform, Model, ...> rock;  